### PR TITLE
[FIX] wrong week number should be base 1 instead of base 0

### DIFF
--- a/planning_week_number/static/src/js/planning_week_number_gantt_renderer.js
+++ b/planning_week_number/static/src/js/planning_week_number_gantt_renderer.js
@@ -13,7 +13,7 @@ odoo.define("planning_week_number.GanttRenderer", function (require) {
             var self = this;
             var dateStart = false;
             var dateEnd = false;
-            var weekNumber = focusDate.clone().weeks() - 1;
+            var weekNumber = focusDate.clone().weeks();
             switch (this.state.scale) {
                 // Add week number for the day view
                 case "day":
@@ -40,8 +40,8 @@ odoo.define("planning_week_number.GanttRenderer", function (require) {
                     );
                 // Add week number for the month view
                 case "month":
-                    var firstDay = focusDate.clone().startOf("month").weeks() - 1;
-                    var lastDay = focusDate.clone().endOf("month").weeks() - 1;
+                    var firstDay = focusDate.clone().startOf("month").weeks();
+                    var lastDay = focusDate.clone().endOf("month").weeks();
                     return _.str.sprintf(
                         "%s ( W%s-W%s )",
                         focusDate.format("MMMM YYYY"),


### PR DESCRIPTION
Before (wrong, http://www.whatweekisit.org/):

![image](https://github.com/Yenthe666/planning/assets/1466356/9038dca6-24ca-4ea2-89df-d02ef18c7c0a)

After (correct):

![image](https://github.com/Yenthe666/planning/assets/1466356/c21486d3-7fd8-4558-a9b3-4bbb0c69f498)
